### PR TITLE
fix: Handle skipped status for PR-conditional jobs in CI Summary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,6 +128,7 @@ jobs:
     name: CI Summary
     runs-on: ubuntu-24.04
     needs:
+      - lint-pr
       - pre-commit
       - dockerfile-lint
       - security-gitleaks
@@ -145,6 +146,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Lint PR Title | ${{ needs.lint-pr.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Pre-commit | ${{ needs.pre-commit.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Dockerfile Lint | ${{ needs.dockerfile-lint.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Gitleaks | ${{ needs.security-gitleaks.result }} |" >> $GITHUB_STEP_SUMMARY
@@ -161,18 +163,24 @@ jobs:
           if [ "${{ needs.pre-commit.result }}" != "success" ] || \
              [ "${{ needs.dockerfile-lint.result }}" != "success" ] || \
              [ "${{ needs.security-gitleaks.result }}" != "success" ] || \
-             [ "${{ needs.security-trivy.result }}" != "success" ] || \
-             [ "${{ needs.test-terraform-configs.result }}" != "success" ] || \
-             [ "${{ needs.build-pr-image.result }}" != "success" ] || \
-             [ "${{ needs.test-image.result }}" != "success" ]; then
-            echo "❌ CI checks failed"
+             [ "${{ needs.test-terraform-configs.result }}" != "success" ]; then
+            echo "❌ Required CI checks failed"
             exit 1
           fi
 
-          # Check optional jobs (only if they ran)
-          if [ "${{ needs.security-codeql.result }}" == "failure" ] || \
+          # Check PR-conditional jobs (must be success or skipped)
+          if ([ "${{ needs.security-trivy.result }}" != "success" ] && [ "${{ needs.security-trivy.result }}" != "skipped" ]) || \
+             ([ "${{ needs.build-pr-image.result }}" != "success" ] && [ "${{ needs.build-pr-image.result }}" != "skipped" ]) || \
+             ([ "${{ needs.test-image.result }}" != "success" ] && [ "${{ needs.test-image.result }}" != "skipped" ]); then
+            echo "❌ PR-conditional CI checks failed"
+            exit 1
+          fi
+
+          # Check optional jobs (only if they ran and failed)
+          if [ "${{ needs.lint-pr.result }}" == "failure" ] || \
+             [ "${{ needs.security-codeql.result }}" == "failure" ] || \
              [ "${{ needs.dependency-review.result }}" == "failure" ]; then
-            echo "❌ CI checks failed"
+            echo "❌ Optional CI checks failed"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Fixed CI Summary job failure when triggered via workflow_dispatch
- Updated status check logic to accept "skipped" for PR-conditional jobs
- Added lint-pr to CI Summary for completeness

## Problem
The CI workflow failed when triggered manually (workflow_dispatch) because the CI Summary job expected PR-conditional jobs (build-pr-image, security-trivy, test-image) to have "success" status, but they were "skipped" when not running on a PR.

## Solution
- Separated job types: required, PR-conditional, and optional
- Updated status checks to accept both "success" and "skipped" for PR-conditional jobs
- Added lint-pr to the CI Summary needs and status checks

## Test Results
✅ Workflow run: https://github.com/duyluann/terraform-toolkit-docker/actions/runs/21086907030
- Required jobs: All passed
- PR-conditional jobs: Properly handled as skipped
- CI Summary: Now succeeds instead of failing

## Verification
- [x] Tested with workflow_dispatch trigger
- [x] All required jobs must succeed
- [x] PR-conditional jobs accept "success" or "skipped"
- [x] Optional jobs only fail if they run and fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized the continuous integration validation pipeline with new conditional logic to improve efficiency for both required and optional checks
  * Added pull request title linting validation as a newly required check component
  * Enhanced continuous integration failure reporting with categorized error messages that distinguish between different types of check failures to improve troubleshooting and provide better developer feedback

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->